### PR TITLE
Increase Nginx header and body buffer sizes to fix Chrome debugger errors

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -27,8 +27,13 @@ http {
     types_hash_max_size 2048; # Maximum size of MIME types hash table
     
     # Header Buffer Settings - Fix for "400 Request Header Or Cookie Too Large"
-    client_header_buffer_size 8k; # Increase from default 1k to handle large headers
-    large_client_header_buffers 8 16k; # Increase from default 4 8k for Chrome DevTools Protocol
+    # Aggressive increase to handle Chrome DevTools Protocol large headers
+    client_header_buffer_size 16k; # Increase from default 1k to handle large headers
+    large_client_header_buffers 16 32k; # Increase from default 4 8k for Chrome DevTools Protocol
+    
+    # Additional buffer settings for request bodies
+    client_body_buffer_size 128k; # Increase body buffer size
+    client_max_body_size 10m; # Maximum client body size
     
     # MIME Types
     include /etc/nginx/mime.types; # Load MIME type mappings


### PR DESCRIPTION
## Summary
- Resolves Chrome DevTools Protocol connection errors caused by large request headers
- Increases Nginx buffer sizes for client headers and bodies to handle larger payloads

## Changes

### Nginx Configuration
- **client_header_buffer_size** increased from 8k to 16k to better accommodate large headers
- **large_client_header_buffers** increased from 8 buffers of 16k to 16 buffers of 32k for Chrome DevTools Protocol
- Added **client_body_buffer_size** set to 128k to increase request body buffer size
- Added **client_max_body_size** set to 10m to allow larger client request bodies

## Test plan
- [x] Verified Chrome debugger can connect without "400 Request Header Or Cookie Too Large" errors
- [x] Tested Nginx reverse proxy with large headers and request bodies
- [x] Confirmed no regressions in normal request handling

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/be09fcdd-2dba-42cc-a500-d8d31c36b807