### PR TITLE
fix: Increase header buffer sizes to resolve Chrome debugger 400 errors

### DIFF
--- a/chrome-debugger.conf
+++ b/chrome-debugger.conf
@@ -2,6 +2,13 @@
 # This configuration proxies Chrome DevTools debugger with full WebSocket support
 # Same-port redirection: Chrome on port 9222 → Nginx listens on port 9222
 
+# Header Buffer Settings - Fix for "400 Request Header Or Cookie Too Large"
+# Maximum settings to handle Chrome DevTools Protocol large headers
+client_header_buffer_size 32k;
+large_client_header_buffers 32 64k;
+client_body_buffer_size 128k;
+client_max_body_size 10m;
+
 server {
     # Listen on same port as Chrome debugger port
     # Same-port redirection: 9222 → 9222


### PR DESCRIPTION
## Summary
- Fixes "400 Request Header Or Cookie Too Large" errors when proxying Chrome DevTools debugger
- Increases Nginx buffer sizes to handle large headers from Chrome DevTools Protocol

## Changes

### Configuration Updates
- Updated `chrome-debugger.conf` to add the following buffer settings:
  - `client_header_buffer_size` set to 32k
  - `large_client_header_buffers` set to 32 buffers of 64k each
  - `client_body_buffer_size` set to 128k
  - `client_max_body_size` set to 10m

These changes ensure that Nginx can properly handle the large headers sent by Chrome DevTools, preventing connection errors.

## Test plan
- [x] Verified that Chrome debugger connections no longer fail with 400 errors
- [x] Confirmed that WebSocket proxying for Chrome DevTools works as expected
- [x] Tested with multiple Chrome versions to ensure compatibility

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/be09fcdd-2dba-42cc-a500-d8d31c36b807