### PR TITLE
fix: remove aggressive header buffer settings causing Chrome debugger errors

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -26,14 +26,6 @@ http {
     keepalive_timeout 65; # Keep connections alive for 65 seconds
     types_hash_max_size 2048; # Maximum size of MIME types hash table
     
-    # Header Buffer Settings - Fix for "400 Request Header Or Cookie Too Large"
-    # Aggressive increase to handle Chrome DevTools Protocol large headers
-    client_header_buffer_size 16k; # Increase from default 1k to handle large headers
-    large_client_header_buffers 16 32k; # Increase from default 4 8k for Chrome DevTools Protocol
-    
-    # Additional buffer settings for request bodies
-    client_body_buffer_size 128k; # Increase body buffer size
-    client_max_body_size 10m; # Maximum client body size
     
     # MIME Types
     include /etc/nginx/mime.types; # Load MIME type mappings


### PR DESCRIPTION
## Summary
- Removes aggressive client header buffer settings from nginx.conf
- Fixes Chrome DevTools Protocol connection errors caused by large header buffers

## Changes

### Configuration
- Deleted the following nginx buffer settings from `nginx.conf`:
  - `client_header_buffer_size 16k`
  - `large_client_header_buffers 16 32k`
  - `client_body_buffer_size 128k`
  - `client_max_body_size 10m`
- These settings were originally added to fix "400 Request Header Or Cookie Too Large" errors but caused issues with Chrome debugger connections.

## Test plan
- [x] Verified Chrome DevTools debugger connects without errors after removing buffer overrides
- [x] Confirmed no regressions in handling normal client requests
- [x] Ensured nginx starts and runs with updated configuration

This change improves compatibility with Chrome debugging tools by reverting overly aggressive buffer size increases.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/be09fcdd-2dba-42cc-a500-d8d31c36b807